### PR TITLE
Removed email_reminder_days from default options.picklists file

### DIFF
--- a/defaults/options.picklists.js
+++ b/defaults/options.picklists.js
@@ -122,11 +122,6 @@ module.exports = {
 		value: 'value',
 		static: true
 	},
-	'email_reminder_days': {
-		text: 'value',
-		value: 'value',
-		static: true
-	},
 	'todo_statuses': {
 		text: 'value',
 		value: 'value',


### PR DESCRIPTION
_email_reminder_days_ is not a picklist anymore in v4.x
- Removed email reminder days from _defaults/options.picklists.js_

