### PR TITLE
Added sorting and ranking to picklists

### DIFF
--- a/config.js
+++ b/config.js
@@ -23,6 +23,8 @@ module.exports = {
 		'tab-name-tmpl.dust': 'public/templates/case',
 		'tab-name-view.js': 'public/views/case'
 	},
+	sortPicklist: false,
+	rankPicklist: false,
 	picklistOtherValues: [
 		'Other',
 		'N/A'

--- a/config.js
+++ b/config.js
@@ -22,5 +22,9 @@ module.exports = {
 		'options.case-details-tabs-ex.js': 'public/config',
 		'tab-name-tmpl.dust': 'public/templates/case',
 		'tab-name-view.js': 'public/views/case'
-	}
+	},
+	picklistOtherValues: [
+		'Other',
+		'N/A'
+	]
 }

--- a/generate-picklist.js
+++ b/generate-picklist.js
@@ -5,8 +5,16 @@ var pluralize = require('pluralize');
 var Papa = require('papaparse');
 var configGen = require('./config.js');
 
-var sortList = process.env.SORT === 'true';
-var rankList = process.env.RANK === 'true';
+var sortList = configGen.sortPicklist;
+var rankList = configGen.rankPicklist;
+
+if (process.env.SORT) {
+	sortList = process.env.SORT === 'true';
+}
+
+if (process.env.RANK) {
+	rankList = process.env.RANK === 'true';
+}
 
 // Run
 fs.readFile(path.join(configGen.inDir, 'picklists.txt'), 'utf8', function(err, data) {


### PR DESCRIPTION
Added ability to sort and rank picklists.

- Sorting is based on the parents and then value properties of the list item
- Sorting also moves 'Other' & 'N/A' to the bottom of the list
- Sort & rank flags are currently passed through the command line
  - SORT=true
  - RANK=true
- Sample command to sort & rank a list
  - `SORT=true RANK=true node generate-picklist.js`