### PR TITLE
Added purge notice banner to custom forms

### DIFF
--- a/custom-form/entity-name-details-tmpl.dust
+++ b/custom-form/entity-name-details-tmpl.dust
@@ -1,3 +1,14 @@
+{?model.datePurged}
+    <div class="alert alert-danger">
+        {@resource key="record_purged_info" /}
+    </div>
+{:else}
+    {?model.pendingPurgeDate}
+        <div class="alert alert-danger">
+            {@resource key="record_pending_purge_info" /}
+        </div>
+    {/model.pendingPurgeDate}
+{/model.datePurged}
 <!-- Buttons to edit and delete -->
 <div class="pull-right btn-toolbar-sticky no-print" data-print="false">
   <div class="btn-toolbar" data-readonly="true">


### PR DESCRIPTION
- Feature is only supported in platform version v4.1 upwards
- Added a purge notice banner to custom forms that have been marked for purge (See screenshot below).

![screen shot 2019-03-01 at 8 18 24 am](https://user-images.githubusercontent.com/34244366/53650700-1ff97c80-3c13-11e9-9d60-0dae3fe29664.png)

